### PR TITLE
Add filter command with composable predicate chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🖼️ ASCII art banner with gradient coloring (figlet + gradient-string)
 - ⏳ Spinner with auto-succeed/fail (ora)
 - 📋 Styled analysis tables with progress bars (cli-table3)
+- 🔍 `filter` command with --level, --keyword, --regex, --from, --to options
+- 🎯 Filter engine with AND-composed predicate chains
+- ✅ Input validators for file paths, regex, line ranges, level lists

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,9 @@ import { resolveFilePath, fileExists } from "../utils/fs.js";
 import { showMiniHeader } from "../ui/banner.js";
 import { withSpinner } from "../ui/spinner.js";
 import { renderAnalysisTable } from "../ui/table.js";
+import { filterEntries } from "../core/filter.js";
+import { parseLevelList } from "../utils/validators.js";
+import { renderFilteredTable } from "../ui/table.js";
 
 const program = new Command();
 
@@ -43,6 +46,44 @@ program
     const result = analyzeEntries(entries, resolved, totalLines);
 
     renderAnalysisTable(result);
+  });
+
+program
+  .command("filter [file]")
+  .alias("f")
+  .description("Filter log entries by criteria")
+  .option(
+    "-l, --level <levels>",
+    "Comma-separated log levels (e.g. ERROR,WARN)",
+  )
+  .option("-k, --keyword <word>", "Case-insensitive keyword search")
+  .option("-r, --regex <pattern>", "Regex pattern to match")
+  .option("--from <line>", "Start line number", parseInt)
+  .option("--to <line>", "End line number", parseInt)
+  .option("-o, --output <path>", "Output file path (saves instead of printing)")
+  .action(async (file: string | undefined, options: any) => {
+    if (!file) {
+      console.error("\n  Error: Please provide a log file path.\n");
+      process.exit(1);
+    }
+
+    showMiniHeader();
+    const resolved = resolveFilePath(file);
+    validateFileOrExit(resolved);
+
+    const entries = await withSpinner("Parsing log file…", () =>
+      parseLogFile(resolved),
+    );
+
+    const filterOptions: any = {};
+    if (options.level) filterOptions.levels = parseLevelList(options.level);
+    if (options.keyword) filterOptions.keyword = options.keyword;
+    if (options.regex) filterOptions.regex = options.regex;
+    if (options.from) filterOptions.fromLine = options.from;
+    if (options.to) filterOptions.toLine = options.to;
+
+    const filtered = filterEntries(entries, filterOptions);
+    renderFilteredTable(filtered);
   });
 
 program.parse();

--- a/src/core/filter.ts
+++ b/src/core/filter.ts
@@ -1,0 +1,83 @@
+import type { LogEntry, FilterOptions } from "../types/index.js";
+
+function buildFilterChain(
+  options: FilterOptions,
+): Array<(entry: LogEntry) => boolean> {
+  const filters: Array<(entry: LogEntry) => boolean> = [];
+
+  if (options.levels && options.levels.length > 0) {
+    // Set for O(1) lookup instead of O(n) Array.includes()
+    const upperLevels = new Set(options.levels.map((l) => l.toUpperCase()));
+    filters.push((entry) => upperLevels.has(entry.level.toUpperCase()));
+  }
+
+  if (options.keyword) {
+    const lower = options.keyword.toLowerCase();
+    filters.push((entry) => entry.raw.toLowerCase().includes(lower));
+  }
+
+  if (options.regex) {
+    const re = new RegExp(options.regex, "i");
+    filters.push((entry) => re.test(entry.raw));
+  }
+
+  if (options.fromLine !== undefined) {
+    filters.push((entry) => entry.lineNumber >= options.fromLine!);
+  }
+
+  if (options.toLine !== undefined) {
+    filters.push((entry) => entry.lineNumber <= options.toLine!);
+  }
+
+  if (options.fromDate) {
+    filters.push(
+      (entry) => !!entry.timestamp && entry.timestamp >= options.fromDate!,
+    );
+  }
+
+  if (options.toDate) {
+    filters.push(
+      (entry) => !!entry.timestamp && entry.timestamp <= options.toDate!,
+    );
+  }
+
+  return filters;
+}
+
+export function filterEntries(
+  entries: LogEntry[],
+  options: FilterOptions,
+): LogEntry[] {
+  const filters = buildFilterChain(options);
+  if (filters.length === 0) return entries;
+  return entries.filter((entry) => filters.every((fn) => fn(entry)));
+}
+
+/**
+ * Extract all unique log levels present in entries, sorted alphabetically.
+ * Set naturally deduplicates.
+ */
+export function getUniqueLevels(entries: LogEntry[]): string[] {
+  const levels = new Set<string>();
+  for (const entry of entries) {
+    levels.add(entry.level);
+  }
+  return [...levels].sort();
+}
+
+/**
+ * Search entries by keyword with match position tracking.
+ * matchIndex enables highlighting in future UIs.
+ */
+export function searchEntries(
+  entries: LogEntry[],
+  keyword: string,
+): Array<LogEntry & { matchIndex: number }> {
+  const lower = keyword.toLowerCase();
+  return entries
+    .filter((entry) => entry.raw.toLowerCase().includes(lower))
+    .map((entry) => ({
+      ...entry,
+      matchIndex: entry.raw.toLowerCase().indexOf(lower),
+    }));
+}

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,0 +1,36 @@
+import { fileExists } from "./fs.js";
+
+export function validateFilePath(filepath: string): string | null {
+  if (!filepath || filepath.trim() === "") {
+    return "File path cannot be empty";
+  }
+  if (!fileExists(filepath)) {
+    return `file not found : ${filepath}`;
+  }
+  return null;
+}
+
+export function validateRegex(pattern: string): string | null {
+  try {
+    new RegExp(pattern);
+    return null;
+  } catch {
+    return `Invalid regex pattern: ${pattern}`;
+  }
+}
+
+export function validateLineRange(start: number, end: number): string | null {
+  if (!Number.isInteger(start) || start < 1)
+    return "Start line must be a positive integer";
+  if (!Number.isInteger(end) || end < 1)
+    return "End line must be a positive integer";
+  if (start > end) return "Start line cannot be greater than end line";
+  return null;
+}
+
+export function parseLevelList(input: string): string[] {
+  return input
+    .split(",")
+    .map((s) => s.trim().toUpperCase())
+    .filter((s) => s.length > 0);
+}


### PR DESCRIPTION
ntroduces the filter engine and CLI command for searching and filtering log entries. The filter system uses a composable predicate chain architecture where each filter option becomes an independent closure, composed with AND logic for maximum flexibility.

#### Changes

##### Filter Engine (`src/core/filter.ts`) — [NEW]
- **`buildFilterChain(options)`** — Converts `FilterOptions` into an array of predicate closures:
  - Level filter: `Set<string>` for O(1) membership test
  - Keyword filter: case-insensitive `includes()` on raw text
  - Regex filter: compiled `RegExp` tested against raw text
  - Line range: `fromLine` / `toLine` bounds checking
  - Date range: timestamp comparison with null guards
- **`filterEntries(entries, options)`** — Applies chain with `entries.filter(e => filters.every(fn => fn(e)))` — ALL predicates must pass
- **`getUniqueLevels(entries)`** — Extracts and sorts unique levels via `Set`
- **`searchEntries(entries, keyword)`** — Returns matches with `matchIndex` property for future highlighting

##### Validators (`src/utils/validators.ts`) — [NEW]
- `validateFilePath(path)` — Returns `null` (valid) or error message string
- `validateRegex(pattern)` — Tests by attempting `new RegExp()` construction
- `validateLineRange(start, end)` — Validates positive integers with start ≤ end
- `parseLevelList(input)` — Parses `"ERROR, warn, INFO"` → `["ERROR", "WARN", "INFO"]`

##### CLI Updates (`src/cli/index.ts`) — [MODIFY]
- `filter [file]` command with alias `f`
- Options: `-l/--level`, `-k/--keyword`, `-r/--regex`, `--from`, `--to`, `-o/--output`
- Results rendered via `renderFilteredTable()`

#### Verification

```bash
node dist/cli/index.cjs filter test.log --level ERROR        # Only ERROR entries
node dist/cli/index.cjs filter test.log --level ERROR,WARN   # ERROR + WARN entries
node dist/cli/index.cjs filter test.log --keyword timeout    # Keyword search
```

#### Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

#### Related Issue

Closes #9 

#### Checklist

- [x] The build succeeds (`npm run build`)
- [x] My commits follow the Conventional Commits convention